### PR TITLE
WIP: Create a boost::asio mainloop integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,13 @@ AC_ARG_ENABLE(glib,
 	[enable_glib=no]
 )
 
+AC_ARG_ENABLE(boost,
+	AS_HELP_STRING([--enable-boost],
+		[enable boost integration]),
+	[enable_boost=$enableval],
+	[enable_boost=no]
+)
+
 AC_ARG_ENABLE(doxygen-docs,
 	AS_HELP_STRING([--enable-doxygen-docs],
 		[build DOXYGEN documentation (requires Doxygen)]),
@@ -119,6 +126,22 @@ AC_SUBST(ecore_LIBS)
 AM_CONDITIONAL(ENABLE_ECORE, test 1 = 1)
 else
 AM_CONDITIONAL(ENABLE_ECORE, test 0 = 1)
+fi
+
+if test "$enable_boost" = "yes" ; then
+# No pkg config for this one...
+# Bad check for the directly required headers
+# There's no sensible way to check for boost at all without
+# using boost.m4, but that is GPLv3
+AC_CHECK_HEADERS(
+	[boost/assert.hpp boost/asio.hpp boost/bind.hpp boost/system/error_code.hpp],
+	[],
+	[AC_MSG_ERROR([You need the boost libraries][http://www.boost.org])])
+AC_SUBST(boost_CFLAGS)
+AC_SUBST(boost_LIBS, [-lboost_system])
+AM_CONDITIONAL(ENABLE_BOOST, test 1 = 1)
+else
+AM_CONDITIONAL(ENABLE_BOOST, test 0 = 1)
 fi
 
 EXPAT_VERSION=2.1.0

--- a/include/dbus-c++/boost-asio-integration.h
+++ b/include/dbus-c++/boost-asio-integration.h
@@ -1,0 +1,123 @@
+/*
+ *
+ *  D-Bus++ - C++ bindings for D-Bus
+ *
+ *  Copyright (C) 2005-2007  Paolo Durante <shackan@gmail.com>
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+
+#ifndef __DBUSXX_BOOST_ASIO_INTEGRATION_H
+#define __DBUSXX_BOOST_ASIO_INTEGRATION_H
+
+#ifdef HAVE_WIN32
+#error "Boost dispatcher currently has no support for Windows sockets! Please implement"
+#endif
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "api.h"
+#include "dispatcher.h"
+
+namespace DBus {
+
+namespace Boost {
+
+class BusDispatcher;
+
+class DXXAPI BusTimeout : public Timeout
+{
+private:
+
+	BusTimeout(Timeout::Internal *, boost::asio::io_service *);
+
+	~BusTimeout();
+
+	void toggle();
+
+	void enable();
+
+	void disable();
+
+	void callback(const boost::system::error_code &);
+
+private:
+
+	boost::asio::io_service *_ctx;
+	boost::asio::deadline_timer *_timer;
+
+friend class BusDispatcher;
+};
+
+class DXXAPI BusWatch : public Watch
+{
+private:
+
+	BusWatch(Watch::Internal *, boost::asio::io_service *, BusDispatcher *);
+
+	~BusWatch();
+
+	void toggle();
+
+	void enable();
+
+	void disable();
+
+	void callback(const boost::system::error_code &, size_t, int);
+
+private:
+
+	boost::asio::io_service *_ctx;
+	BusDispatcher *_dispatcher;
+	boost::asio::posix::stream_descriptor *_wch;
+
+friend class BusDispatcher;
+};
+
+class DXXAPI BusDispatcher : public Dispatcher
+{
+public:
+
+	BusDispatcher();
+	~BusDispatcher();
+
+	void attach(boost::asio::io_service *);
+
+	void enter() {}
+
+	void leave() {}
+
+	Timeout *add_timeout(Timeout::Internal *);
+
+	void rem_timeout(Timeout *);
+
+	Watch *add_watch(Watch::Internal *);
+
+	void rem_watch(Watch *);
+
+private:
+
+	boost::asio::io_service *_ctx;
+};
+
+} /* namespace Boost */
+
+} /* namespace DBus */
+
+#endif//__DBUSXX_BOOST_ASIO_INTEGRATION_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS = \
 	$(dbus_CFLAGS) \
 	$(glib_CFLAGS) \
 	$(ecore_CFLAGS) \
+	$(boost_CFLAGS) \
 	$(PTHREAD_CFLAGS) \
 	$(PRIVATE_CFLAGS) \
 	-I$(top_srcdir)/include \
@@ -15,6 +16,11 @@ endif
 if ENABLE_ECORE
 ECORE_H = $(HEADER_DIR)/ecore-integration.h
 ECORE_CPP = ecore-integration.cpp
+endif
+
+if ENABLE_BOOST
+BOOST_H = $(HEADER_DIR)/boost-asio-integration.h
+BOOST_CPP = boost-asio-integration.cpp
 endif
 
 HEADER_DIR  = $(top_srcdir)/include/dbus-c++
@@ -37,14 +43,35 @@ HEADER_FILES = \
 	$(HEADER_DIR)/api.h \
 	$(HEADER_DIR)/eventloop.h \
 	$(HEADER_DIR)/eventloop-integration.h \
-	$(GLIB_H) $(ECORE_H)
+	$(GLIB_H) $(ECORE_H) $(BOOST_H)
 
 lib_includedir=$(includedir)/dbus-c++-1/dbus-c++/
 lib_include_HEADERS = $(HEADER_FILES)
 
 lib_LTLIBRARIES = libdbus-c++-1.la
-libdbus_c___1_la_SOURCES = $(HEADER_FILES) interface.cpp object.cpp introspection.cpp debug.cpp types.cpp connection.cpp connection_p.h property.cpp dispatcher.cpp dispatcher_p.h pendingcall.cpp pendingcall_p.h error.cpp internalerror.h message.cpp message_p.h server.cpp server_p.h eventloop.cpp eventloop-integration.cpp $(GLIB_CPP) $(ECORE_CPP)
-libdbus_c___1_la_LIBADD = $(dbus_LIBS) $(glib_LIBS) $(PTHREAD_CFLAGS) $(PTHREAD_LIBS) $(ecore_LIBS)
+libdbus_c___1_la_SOURCES = $(HEADER_FILES) \
+	interface.cpp \
+	object.cpp \
+	introspection.cpp \
+	debug.cpp \
+	types.cpp \
+	connection.cpp \
+	connection_p.h \
+	property.cpp \
+	dispatcher.cpp \
+	dispatcher_p.h \
+	pendingcall.cpp \
+	pendingcall_p.h \
+	error.cpp \
+	internalerror.h \
+	message.cpp \
+	message_p.h \
+	server.cpp \
+	server_p.h \
+	eventloop.cpp \
+	eventloop-integration.cpp \
+	$(GLIB_CPP) $(ECORE_CPP) $(BOOST_CPP)
+libdbus_c___1_la_LIBADD = $(dbus_LIBS) $(glib_LIBS) $(boost_LIBS) $(PTHREAD_CFLAGS) $(PTHREAD_LIBS) $(ecore_LIBS)
 
 MAINTAINERCLEANFILES = \
 	Makefile.in

--- a/src/boost-asio-integration.cpp
+++ b/src/boost-asio-integration.cpp
@@ -1,0 +1,213 @@
+/*
+ *
+ *  D-Bus++ - C++ bindings for D-Bus
+ *
+ *  Copyright (C) 2005-2007  Paolo Durante <shackan@gmail.com>
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <dbus-c++/boost-asio-integration.h>
+
+#include <boost/asio.hpp>
+#include <boost/assert.hpp>
+#include <boost/bind.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <dbus/dbus.h> // for DBUS_WATCH_*
+
+using namespace DBus;
+
+Boost::BusTimeout::BusTimeout(Timeout::Internal *ti, boost::asio::io_service *ctx)
+: Timeout(ti), _ctx(ctx), _timer(NULL)
+{
+	if (Timeout::enabled())
+		enable();
+}
+
+Boost::BusTimeout::~BusTimeout()
+{
+	disable();
+}
+
+void Boost::BusTimeout::toggle()
+{
+	debug_log("boost: timeout %p toggled (%s)", this, Timeout::enabled() ? "on":"off");
+
+	if (Timeout::enabled())
+		enable();
+	else
+		disable();
+}
+
+void Boost::BusTimeout::enable()
+{
+	if (_timer)
+		disable();
+
+	_timer = new boost::asio::deadline_timer(*_ctx, boost::posix_time::milliseconds(Timeout::interval()));
+	_timer->async_wait(boost::bind(&BusTimeout::callback, this, _1));
+}
+
+void Boost::BusTimeout::disable()
+{
+	if (!_timer)
+		return;
+
+	_timer->cancel();
+	delete _timer;
+	_timer = NULL;
+}
+
+void Boost::BusTimeout::callback(const boost::system::error_code &ec)
+{
+	// this error is a boost internal that is triggered when
+	// cancel is called on the timer, just abort
+	if (ec == boost::asio::error::operation_aborted)
+		return;
+
+	Timeout::handle();
+	_timer->expires_from_now(boost::posix_time::milliseconds(Timeout::interval()));
+	_timer->async_wait(boost::bind(&BusTimeout::callback, this, _1));
+}
+
+Boost::BusWatch::BusWatch(Watch::Internal *wi, boost::asio::io_service *ctx, BusDispatcher *dispatcher)
+: Watch(wi), _ctx(ctx), _dispatcher(dispatcher), _wch(NULL)
+{
+	if (Watch::enabled())
+		enable();
+}
+
+Boost::BusWatch::~BusWatch()
+{
+	disable();
+}
+
+void Boost::BusWatch::toggle()
+{
+	debug_log("boost: watch %p toggled (%s)", this, Watch::enabled() ? "on":"off");
+
+	if (Watch::enabled())
+		enable();
+	else
+		disable();
+}
+
+void Boost::BusWatch::enable()
+{
+	if (_wch)
+		disable();
+
+	_wch = new boost::asio::posix::stream_descriptor(*_ctx, ::dup(Watch::descriptor()));
+
+	// there's currently no good detection in boost for HUP events
+	if (Watch::flags() & (DBUS_WATCH_READABLE | DBUS_WATCH_ERROR))
+		_wch->async_read_some(boost::asio::null_buffers(), boost::bind(&BusWatch::callback, this, _1, _2, Watch::flags() & (DBUS_WATCH_READABLE | DBUS_WATCH_ERROR)));
+	if (Watch::flags() & DBUS_WATCH_WRITABLE)
+		_wch->async_write_some(boost::asio::null_buffers(), boost::bind(&BusWatch::callback, this, _1, _2, DBUS_WATCH_WRITABLE));
+}
+
+void Boost::BusWatch::disable()
+{
+	if (!_wch)
+		return;
+
+	_wch->cancel();
+	delete _wch;
+	_wch = NULL;
+}
+
+void Boost::BusWatch::callback(const boost::system::error_code &ec, size_t, int flag)
+{
+	if (ec)
+	{
+		// this error is a boost internal that is triggered when
+		// cancel is called on the watch, just abort
+		if (ec == boost::asio::error::operation_aborted)
+			return;
+		if (flag & DBUS_WATCH_ERROR)
+			Watch::handle(DBUS_WATCH_ERROR);
+	}
+	else
+		Watch::handle(flag & ~DBUS_WATCH_ERROR);
+	// boost implements a one-shot idiom, keep adding the callback back
+	if (flag & (DBUS_WATCH_READABLE | DBUS_WATCH_ERROR))
+	{
+		_wch->async_read_some(boost::asio::null_buffers(), boost::bind(&BusWatch::callback, this, _1, _2, flag));
+	}
+	if (flag & DBUS_WATCH_WRITABLE)
+	{
+		_wch->async_write_some(boost::asio::null_buffers(), boost::bind(&BusWatch::callback, this, _1, _2, flag));
+	}
+
+	if (_dispatcher->has_something_to_dispatch())
+		_dispatcher->dispatch_pending();
+}
+
+Boost::BusDispatcher::BusDispatcher()
+: _ctx(NULL)
+{
+}
+
+Boost::BusDispatcher::~BusDispatcher()
+{
+// TODO: Destroy allocated objects such as watches and timers
+}
+
+void Boost::BusDispatcher::attach(boost::asio::io_service *ctx)
+{
+	BOOST_ASSERT(_ctx == NULL); // just to be sane
+	BOOST_ASSERT(ctx != NULL);
+
+	_ctx = ctx;
+}
+
+Timeout *Boost::BusDispatcher::add_timeout(Timeout::Internal *wi)
+{
+	Timeout *t = new Boost::BusTimeout(wi, _ctx);
+
+	debug_log("boost: added timeout %p (%s)", t, t->enabled() ? "on":"off");
+
+	return t;
+}
+
+void Boost::BusDispatcher::rem_timeout(Timeout *t)
+{
+	debug_log("boost: removed timeout %p", t);
+
+	delete t;
+}
+
+Watch *Boost::BusDispatcher::add_watch(Watch::Internal *wi)
+{
+	Watch *w = new Boost::BusWatch(wi, _ctx, this);
+
+	debug_log("boost: added watch %p (%s) fd=%d flags=%d",
+		w, w->enabled() ? "on":"off", w->descriptor(), w->flags()
+	);
+	return w;
+}
+
+void Boost::BusDispatcher::rem_watch(Watch *w)
+{
+	debug_log("boost: removed watch %p", w);
+
+	delete w;
+}


### PR DESCRIPTION
Submitting before it's done for reviewing purposes.

This extends dbus-c++ to connect with a boost::asio mainloop.

Current remaining tasks:
- [ ] Run valgrind to check for memory leaks
- [ ] Solve if the boost.m4 plugin (GPLv3) for autoconf is compatible with LGPLv2.1 for this usage scenario
